### PR TITLE
fix "About" URL in CustomHeader.vue

### DIFF
--- a/client/src/components/navigation/CustomHeader.vue
+++ b/client/src/components/navigation/CustomHeader.vue
@@ -20,7 +20,7 @@
                 <v-card-text>
                     <h3>What is this?</h3>
                     <p>
-                        This is MappingNorthKorea.com, a collaborative effort to map one of the most isolated countries on earth. Read more on the about page <a @click.stop="infoDialog = false" href="/#/about">here</a>.
+                        This is MappingNorthKorea.com, a collaborative effort to map one of the most isolated countries on earth. Read more on the about page <a @click.stop="infoDialog = false" href="/about">here</a>.
                     </p>
                     <h3>Why are all the buttons disabled?</h3>
                     <p>


### PR DESCRIPTION
NOTE: I have not tested this change!

When I am on https://mappingnorthkorea.com/map and click the question mark in the header row a modal opens. I believe the content of that modal is defined here.

When I click "Read more on the about page here." I am redirected to the URL https://mappingnorthkorea.com/map#/about and see only the map, but not the about page.

When I click in the navigation on About I am redirected to the URL https://mappingnorthkorea.com/about and can read the content I'm interested in. Therefore I assume that the link in this file needs to be changed.