### PR TITLE
Always call JOSM over http

### DIFF
--- a/client/src/components/MapPage/CustomMenuRight.vue
+++ b/client/src/components/MapPage/CustomMenuRight.vue
@@ -428,13 +428,13 @@ export default {
             };
 
             EventBus.$emit('mnk:start-loading', 'sendJOSMCommand');
-            JOSMService.sendJOSMCommand('https://127.0.0.1:8112/load_and_zoom', loadAndZoomParams).catch(() => {
+            JOSMService.sendJOSMCommand('http://127.0.0.1:8111/load_and_zoom', loadAndZoomParams).catch(() => {
                 EventBus.$emit('mnk:message-error', this.$t('request.josm_failed'));
             }).finally(() => {
                 EventBus.$emit('mnk:stop-loading', 'sendJOSMCommand');
             });
             EventBus.$emit('mnk:start-loading', 'sendJOSMImageryCommand');
-            JOSMService.sendJOSMCommand('https://127.0.0.1:8112/imagery', {
+            JOSMService.sendJOSMCommand('http://127.0.0.1:8111/imagery', {
                 type: 'bing',
                 url: 'https://www.bing.com/maps/'
             }).finally(() => {

--- a/client/src/components/navigation/CustomHeaderFaq.vue
+++ b/client/src/components/navigation/CustomHeaderFaq.vue
@@ -31,8 +31,7 @@
             },
             "q6": {
                 "question": "Why does the JOSM map option give an error?",
-                "answer": "For some reason the website can't connect with your JOSM instance. Is JOSM running and is Remote Contol (by HTTPS) enabled? You can enable this in the settings of JOSM. In some browsers it is required to accept the HTTPS certificate before the website can connect to JOSM. To do this, go to {0} in your browser",
-                "link": "https://127.0.0.1:8112/"
+                "answer": "For some reason the website can't connect with your JOSM instance. Is JOSM running and is Remote Contol enabled? You can enable this in the settings of JOSM.",
             },
 
             "confirm": "Got it"


### PR DESCRIPTION
Https in JOSM is unreliable and will be dropped soon. See https://josm.openstreetmap.de/ticket/10033

All modern browsers support calling 127.0.0.1 over http even from https pages, per spec:

w3c/webappsec-mixed-content@349501c
https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy

JOSM's default behaviour is to run without https.

Openstreetmap.org itself also always calls JOSM over http.